### PR TITLE
fix: Add map_location to torch.load for CPU compatibility

### DIFF
--- a/music2emo.py
+++ b/music2emo.py
@@ -290,7 +290,7 @@ class Music2emo:
         model = BTC_model(config=config.model).to(self.device)
 
         if os.path.isfile(model_file):
-            checkpoint = torch.load(model_file)
+            checkpoint = torch.load(model_file, map_location=self.device)
             mean = checkpoint['mean']
             std = checkpoint['std']
             model.load_state_dict(checkpoint['model'])


### PR DESCRIPTION
Thanks for creating and maintaining such a great project!

This PR fixes an issue when loading model checkpoints on CPU-only machines.
Previously, the code used:

```python
checkpoint = torch.load(model_file)
```

This raised a `RuntimeError` if the checkpoint was saved on a CUDA device but loaded on a machine without GPU support.

Updated checkpoint loading to:

```python
checkpoint = torch.load(model_file, map_location=self.device)
```

Ensures compatibility with both GPU and CPU environments.